### PR TITLE
Fix file path issues (see #8)

### DIFF
--- a/lua/telescope/_extensions/media_files.lua
+++ b/lua/telescope/_extensions/media_files.lua
@@ -26,12 +26,13 @@ M.media_preview = defaulter(function(opts)
     get_command = opts.get_command or function(entry)
       local tmp_table = vim.split(entry.value,"\t");
       local preview = opts.get_preview_window()
+      opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
       if vim.tbl_isempty(tmp_table) then
         return {"echo", ""}
       end
       return {
         M.base_directory .. '/scripts/vimg' ,
-        string.format([[%s]],tmp_table[1]),
+        string.format([[%s/%s]], opts.cwd, tmp_table[1]),
         preview.col ,
         preview.line ,
         preview.width ,

--- a/scripts/vimg
+++ b/scripts/vimg
@@ -44,7 +44,7 @@ function draw_preview {
     elif [[ "$1" == "videopreview" ]]; then
         path="${2##*/}"
         echo -e "Loading preview..\nFile: $path"
-        ffmpegthumbnailer -i "${PWD}/${path}" -o "${TMP_FOLDER}/${path}.png" -s 0 -q 10
+        ffmpegthumbnailer -i "${PWD}/$2" -o "${TMP_FOLDER}/${path}.png" -s 0 -q 10
         >"${UEBERZUG_FIFO}" declare -A -p cmd=( \
             [action]=add [identifier]="${PREVIEW_ID}" \
             [x]="${3}" [y]="${4}" \
@@ -54,7 +54,7 @@ function draw_preview {
     elif [[ "$1" == "pdfpreview" ]]; then
         path="${2##*/}"
         echo -e "Loading preview..\nFile: $path"
-        [[ ! -f "${TMP_FOLDER}/${path}.png" ]] && pdftoppm -png -singlefile "$path" "${TMP_FOLDER}/${path}"
+        [[ ! -f "${TMP_FOLDER}/${path}.png" ]] && pdftoppm -png -singlefile "$2" "${TMP_FOLDER}/${path}"
         >"${UEBERZUG_FIFO}" declare -A -p cmd=( \
             [action]=add [identifier]="${PREVIEW_ID}" \
             [x]="${3}" [y]="${4}" \

--- a/scripts/vimg
+++ b/scripts/vimg
@@ -44,7 +44,7 @@ function draw_preview {
     elif [[ "$1" == "videopreview" ]]; then
         path="${2##*/}"
         echo -e "Loading preview..\nFile: $path"
-        ffmpegthumbnailer -i "${PWD}/$2" -o "${TMP_FOLDER}/${path}.png" -s 0 -q 10
+        ffmpegthumbnailer -i "$2" -o "${TMP_FOLDER}/${path}.png" -s 0 -q 10
         >"${UEBERZUG_FIFO}" declare -A -p cmd=( \
             [action]=add [identifier]="${PREVIEW_ID}" \
             [x]="${3}" [y]="${4}" \


### PR DESCRIPTION
- Fix file paths in thumbnailer calls
- Respect `cwd` option and default it to vim's current working directory

Closes #8
