### PR TITLE
feat: custom action on select (see #16, #26)

### DIFF
--- a/lua/telescope/_extensions/media_files.lua
+++ b/lua/telescope/_extensions/media_files.lua
@@ -90,7 +90,7 @@ function M.media_files(opts)
   local sourced_file = require('plenary.debug_utils').sourced_filepath()
   M.base_directory = vim.fn.fnamemodify(sourced_file, ":h:h:h:h")
   opts = opts or {}
-  opts.attach_mappings= function(prompt_bufnr,map)
+  opts.attach_mappings= opts.attach_mappings or function(prompt_bufnr,map)
     actions.select_default:replace(function()
       local entry = action_state.get_selected_entry()
       actions.close(prompt_bufnr)

--- a/lua/telescope/_extensions/media_files.lua
+++ b/lua/telescope/_extensions/media_files.lua
@@ -90,7 +90,11 @@ function M.media_files(opts)
   local sourced_file = require('plenary.debug_utils').sourced_filepath()
   M.base_directory = vim.fn.fnamemodify(sourced_file, ":h:h:h:h")
   opts = opts or {}
-  opts.attach_mappings= opts.attach_mappings or function(prompt_bufnr,map)
+  opts.attach_mappings= function(prompt_bufnr,map)
+    if opts.attach_mappings then
+      opts.attach_mappings(prompt_bufnr, map)
+      return true
+    end
     actions.select_default:replace(function()
       local entry = action_state.get_selected_entry()
       actions.close(prompt_bufnr)

--- a/lua/telescope/_extensions/media_files.lua
+++ b/lua/telescope/_extensions/media_files.lua
@@ -90,21 +90,19 @@ function M.media_files(opts)
   local sourced_file = require('plenary.debug_utils').sourced_filepath()
   M.base_directory = vim.fn.fnamemodify(sourced_file, ":h:h:h:h")
   opts = opts or {}
-  opts.attach_mappings= function(prompt_bufnr,map)
-    if opts.attach_mappings then
-      opts.attach_mappings(prompt_bufnr, map)
+  if not opts.attach_mappings then
+    opts.attach_mappings= function(prompt_bufnr,map)
+      actions.select_default:replace(function()
+        local entry = action_state.get_selected_entry()
+        actions.close(prompt_bufnr)
+        if entry[1] then
+          local filename = entry[1]
+          vim.fn.setreg(vim.v.register, filename)
+          vim.notify("The image path has been copied!")
+        end
+      end)
       return true
     end
-    actions.select_default:replace(function()
-      local entry = action_state.get_selected_entry()
-      actions.close(prompt_bufnr)
-      if entry[1] then
-        local filename = entry[1]
-        vim.fn.setreg(vim.v.register, filename)
-        vim.notify("The image path has been copied!")
-      end
-    end)
-    return true
   end
   opts.path_display = { "shorten" }
 


### PR DESCRIPTION
My idea was to expose the `attach_mappings` options to be completely overwritten, similar to telescope's builtin `find_files`. With this, we should be able to close a few issues (#16, #26)