### PR TITLE
Fix previews (video, pdf) and support uppercase file extensions

### DIFF
--- a/scripts/vimg
+++ b/scripts/vimg
@@ -34,7 +34,7 @@ function draw_preview {
       render_at_size "${5}" "${6}" "${2}" "${7}"
 
     elif [[ "$1" == "videopreview" ]]; then
-      if ! command -v viu &> /dev/null; then
+      if ! command -v ffmpegthumbnailer &> /dev/null; then
         echo "ffmpegthumbnailer could not be found in your path,\nplease install it to display video previews"
         exit
       fi
@@ -47,7 +47,7 @@ function draw_preview {
     elif [[ "$1" == "pdfpreview" ]]; then
       path="${2##*/}"
         echo -e "Loading preview..\nFile: $path"
-        [[ ! -f "${TMP_FOLDER}/${path}.png" ]] && pdftoppm -png -singlefile "$2" "${TMP_FOLDER}/${path}.png"
+        [[ ! -f "${TMP_FOLDER}/${path}.png" ]] && pdftoppm -png -singlefile "$2" "${TMP_FOLDER}/${path}"
         clear
         render_at_size "${5}" "${6}" "${TMP_FOLDER}/${path}.png" "${7}"
     fi
@@ -55,6 +55,7 @@ function draw_preview {
 
 function parse_options {
     extension="${1##*.}"
+    extension="${extension,,}"
     case $extension in
     jpg | png | jpeg | webp | svg)
         draw_preview  imagepreview "$1" $2 $3 $4 $5 $6


### PR DESCRIPTION
Hi, I have just tried to setup this plugin in NeoVim.

First of all, thank you for keeping this plugin alive @Conni2461 and everyone else involved!

It seems there are a few problems with file previews in its current version (possibly partly related to the breaking change #35):

1. Video preview does not work when **viu** is not installed
2. PDF preview does not work due to preview script not finding the generated preview files
3. Files with non-lowercase extensions are not supported

This PR is supposed to fix those things:

1. As **viu** does not seem to be used for any previews (only **chafa** is), I have replaced the check for its existence with a check for **ffmpegthumbailer** which seems to be originally intended for that line.
2. **pdftoppm** already appends the file extension `.png` when using the command option `-png` _(This is at least true for my installed version, 23.03.0 - this might need double checking for earlier versions)_. Therefore I have removed the additional `.png` for the output file.
3. When previewing image files with file extensions like `.JPG` or `.MP4`, I get the error message: `unknown file ..image_path.JPG`. I have added a line to make the extracted extension lowercase to match the following case patterns.

@HendrikPetertje Could you verify if these changes still work for you?